### PR TITLE
fix: use snapshot bool as enums are more difficult to support (how to…

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,10 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, Index } from "typeorm";
 
-export enum EventType {
-  Event,
-  Snapshot,
-}
-
 @Entity()
 export class Event {
   @PrimaryGeneratedColumn({ type: "bigint" })
@@ -32,10 +27,6 @@ export class Event {
   @Column({ type: "jsonb" })
   data: any;
 
-  @Column({
-    type: "enum",
-    enum: EventType,
-    default: EventType.Event,
-  })
-  type: EventType;
+  @Column()
+  snapshot: boolean;
 }

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "eventemitter3";
 import { persistenceLayer } from "./persistenceLayer";
-import { Event, EventType } from "./Event";
+import { Event } from "./Event";
 import { MoreThan, Connection, Repository as TypeORMRepository } from "typeorm";
 import debug from "debug";
 
@@ -81,7 +81,7 @@ export class Repository extends EventEmitter {
       },
       where: [
         {
-          type: EventType.Snapshot,
+          snapshot: true,
           entityType: this.EntityType.name,
           [index]: value,
         },
@@ -94,7 +94,7 @@ export class Repository extends EventEmitter {
       },
       where: [
         {
-          type: EventType.Event,
+          snapshot: false,
           entityType: this.EntityType.name,
           [index]: value,
           version: MoreThan(snapshot?.version || 0),
@@ -142,7 +142,7 @@ export class Repository extends EventEmitter {
       event.method = newEvent.method;
       event.entityType = this.EntityType.name;
       event.data = newEvent.data;
-      event.type = EventType.Event;
+      event.snapshot = false;
       return event;
     });
 
@@ -154,7 +154,7 @@ export class Repository extends EventEmitter {
 
       log({ snapshot });
       const snapshotEvent = new Event();
-      snapshotEvent.type = EventType.Snapshot;
+      snapshotEvent.snapshot = true;
       snapshotEvent.method = "snapshot";
       snapshotEvent.data = snapshot;
       snapshotEvent.id = snapshot.id;


### PR DESCRIPTION
… set up in each db, and use from tools like hasura, for example: https://hasura.io/docs/latest/graphql/core/databases/postgres/schema/enums.html)

BREAKING CHANGE: type enum replaced by snapshot boolean

Signed-off-by: Patrick Lee Scott <pat@patscott.io>