### PR TITLE
feat: change schema to use composite primary key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ integration-tests:
 	sleep 5
 	npm run test:integration
 	make down
+
+test:
+	make up
+	sleep 5
+	npm run test:all
+	make down

--- a/__tests__/unit/persistenceLayer-connect-error.ts
+++ b/__tests__/unit/persistenceLayer-connect-error.ts
@@ -4,6 +4,7 @@ jest.mock("typeorm", () => ({
   createConnection: jest.fn(() => Promise.reject("Unable to connect")),
   Connection: jest.fn(),
   PrimaryGeneratedColumn: jest.fn(),
+  PrimaryColumn: jest.fn(),
   Column: jest.fn(),
   Entity: jest.fn(),
   Index: jest.fn(),

--- a/__tests__/unit/persistenceLayer-disconnect-error.ts
+++ b/__tests__/unit/persistenceLayer-disconnect-error.ts
@@ -8,6 +8,7 @@ jest.mock("typeorm", () => ({
   ),
   Connection: jest.fn(),
   PrimaryGeneratedColumn: jest.fn(),
+  PrimaryColumn: jest.fn(),
   Column: jest.fn(),
   Entity: jest.fn(),
   Index: jest.fn(),

--- a/__tests__/unit/persistenceLayer.ts
+++ b/__tests__/unit/persistenceLayer.ts
@@ -9,6 +9,7 @@ jest.mock("typeorm", () => ({
   ),
   Connection: jest.fn(),
   PrimaryGeneratedColumn: jest.fn(),
+  PrimaryColumn: jest.fn(),
   Column: jest.fn(),
   Entity: jest.fn(),
   Index: jest.fn(),

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,15 +1,18 @@
-import { Entity, PrimaryGeneratedColumn, Column, Index } from "typeorm";
+import { Entity, PrimaryColumn, Column, Index } from "typeorm";
 
 @Entity()
 export class Event {
-  @PrimaryGeneratedColumn({ type: "bigint" })
-  _id: string;
+  @PrimaryColumn()
+  entityType: string;
 
-  @Column()
+  @PrimaryColumn()
   @Index()
   id: string;
 
-  @Column()
+  @PrimaryColumn()
+  method: string;
+
+  @PrimaryColumn()
   version: number;
 
   @Column()
@@ -17,12 +20,6 @@ export class Event {
 
   @Column({ type: "bigint" })
   timestamp: number;
-
-  @Column()
-  method: string;
-
-  @Column()
-  entityType: string;
 
   @Column({ type: "jsonb" })
   data: any;


### PR DESCRIPTION
BREAKING CHANGE: _id removed from schema - was auto-incrementing bigint. It did not really serve much of a purpose

Signed-off-by: Patrick Lee Scott <pat@patscott.io>